### PR TITLE
fix realm retrieval by name vs id

### DIFF
--- a/docs/release/1.4.12.txt
+++ b/docs/release/1.4.12.txt
@@ -1,3 +1,4 @@
 - keycloak version 22.0.1
 - switch to JDK 17
 - replace test dependency com.github.stefanbirkner:system-lambda with the fork uk.org.webcompere:system-stubs-core to replace withEnvironmentVariable() by an applicable version for Java17
+- fix realm retrieval by name vs id (previously querying by name or by id was confused in some cases)

--- a/keycloak-plugins/radius-disconnect-plugin/src/test/java/com/github/vzakharchenko/radius/dm/api/RadiusServiceTest.java
+++ b/keycloak-plugins/radius-disconnect-plugin/src/test/java/com/github/vzakharchenko/radius/dm/api/RadiusServiceTest.java
@@ -182,7 +182,7 @@ public class RadiusServiceTest extends AbstractRadiusTest {
         DisconnectMessageModel disconnectMessageModel = new DisconnectMessageModel();
         disconnectMessageModel.setClientId("clientId");
         disconnectMessageModel.setUserId(USER);
-        disconnectMessageModel.setRealmId(REALM_RADIUS_NAME);
+        disconnectMessageModel.setRealmId(REALM_RADIUS_ID);
         when(tableManager.getActiveSession(any(), any(), any())).thenReturn(disconnectMessageModel);
         RadiusServiceModel activeUser = radiusService.getActiveUser("test", "test");
         assertNotNull(activeUser);
@@ -195,7 +195,7 @@ public class RadiusServiceTest extends AbstractRadiusTest {
         DisconnectMessageModel disconnectMessageModel = new DisconnectMessageModel();
         disconnectMessageModel.setClientId("clientId");
         disconnectMessageModel.setUserId(USER);
-        disconnectMessageModel.setRealmId(REALM_RADIUS_NAME);
+        disconnectMessageModel.setRealmId(REALM_RADIUS_ID);
         when(tableManager.getActiveSession(any(), any(), any())).thenReturn(null);
         RadiusServiceModel activeUser = radiusService.getActiveUser("test", "test");
         assertNotNull(activeUser);
@@ -209,7 +209,7 @@ public class RadiusServiceTest extends AbstractRadiusTest {
         DisconnectMessageModel disconnectMessageModel = new DisconnectMessageModel();
         disconnectMessageModel.setClientId("clientId");
         disconnectMessageModel.setUserId(USER);
-        disconnectMessageModel.setRealmId(REALM_RADIUS_NAME);
+        disconnectMessageModel.setRealmId(REALM_RADIUS_ID);
 
         when(tableManager.getAllActiveSessions(any(), any()))
                 .thenReturn(Arrays.asList(disconnectMessageModel));
@@ -226,7 +226,7 @@ public class RadiusServiceTest extends AbstractRadiusTest {
         disconnectMessageModel.setClientId("clientId");
         disconnectMessageModel.setKeycloakSessionId("sessionId");
         disconnectMessageModel.setUserId(USER);
-        disconnectMessageModel.setRealmId(REALM_RADIUS_NAME);
+        disconnectMessageModel.setRealmId(REALM_RADIUS_ID);
         disconnectMessageModel.setFramedIp("test");
         when(tableManager.getActiveSession(any(), any(), any())).thenReturn(disconnectMessageModel);
         RadiusServiceModel test = radiusService.logout("test", "test");
@@ -249,7 +249,7 @@ public class RadiusServiceTest extends AbstractRadiusTest {
         disconnectMessageModel.setClientId("clientId");
         disconnectMessageModel.setKeycloakSessionId("sessionId");
         disconnectMessageModel.setUserId(USER);
-        disconnectMessageModel.setRealmId(REALM_RADIUS_NAME);
+        disconnectMessageModel.setRealmId(REALM_RADIUS_ID);
         disconnectMessageModel.setFramedIp(null);
         when(tableManager.getActiveSession(any(), any(), any())).thenReturn(disconnectMessageModel);
         RadiusServiceModel test = radiusService.logout("test", "test");
@@ -264,7 +264,7 @@ public class RadiusServiceTest extends AbstractRadiusTest {
         disconnectMessageModel.setClientId("clientId");
         disconnectMessageModel.setKeycloakSessionId("sessionId");
         disconnectMessageModel.setUserId(USER);
-        disconnectMessageModel.setRealmId(REALM_RADIUS_NAME);
+        disconnectMessageModel.setRealmId(REALM_RADIUS_ID);
         disconnectMessageModel.setFramedIp("test");
         when(tableManager.getActiveSession(any(), any(), any())).thenReturn(disconnectMessageModel);
         when(userSessionProvider.getUserSession(eq(realmModel), anyString()))

--- a/keycloak-plugins/radius-disconnect-plugin/src/test/java/com/github/vzakharchenko/radius/dm/logout/RadiusLogoutTest.java
+++ b/keycloak-plugins/radius-disconnect-plugin/src/test/java/com/github/vzakharchenko/radius/dm/logout/RadiusLogoutTest.java
@@ -291,7 +291,7 @@ public class RadiusLogoutTest extends AbstractJPATest {
         disconnectMessageModel.setKeycloakSessionId("testSession");
         disconnectMessageModel.setUserId(USER);
         disconnectMessageModel.setClientId(CLIENT_ID);
-        disconnectMessageModel.setRealmId(REALM_RADIUS_NAME);
+        disconnectMessageModel.setRealmId(REALM_RADIUS_ID);
         disconnectMessageModel.setId("sessionId");
         disconnectMessageModel.setCreatedDate(new Date(10000L));
         disconnectMessageModel.setAddress("127.0.0.1");

--- a/keycloak-plugins/radius-plugin/src/main/java/com/github/vzakharchenko/radius/RadiusHelper.java
+++ b/keycloak-plugins/radius-plugin/src/main/java/com/github/vzakharchenko/radius/RadiusHelper.java
@@ -168,7 +168,7 @@ public final class RadiusHelper {
                         .getClientsStream().anyMatch(clientModel -> Objects.equals(
                                 clientModel.getProtocol(),
                                 RadiusLoginProtocolFactory.RADIUS_PROTOCOL)))
-                .collect(Collectors.toList());
+                .toList();
         switch (realms.size()) {
             case 0:
                 throw new IllegalStateException("Radius Realm does not exist. " +
@@ -191,7 +191,7 @@ public final class RadiusHelper {
                 .getValueString(), "@");
         RealmModel realm = null;
         if (StringUtils.isNotEmpty(realmName)) {
-            realm = session.realms().getRealm(realmName);
+            realm = session.realms().getRealmByName(realmName);
         }
         return (realm == null) ? getDefaultRealm(session) : realm;
     }
@@ -202,10 +202,9 @@ public final class RadiusHelper {
         for (String attribute : attributes) {
             String realmName = getRealmName(attribute, radiusPacket);
             if (realmName != null) {
-                return session.realms().getRealm(realmName);
+                return session.realms().getRealmByName(realmName);
             }
         }
-
         return getRealmFromUserName(session, radiusPacket);
     }
 

--- a/keycloak-plugins/radius-plugin/src/main/java/com/github/vzakharchenko/radius/event/log/EventLoggerUtils.java
+++ b/keycloak-plugins/radius-plugin/src/main/java/com/github/vzakharchenko/radius/event/log/EventLoggerUtils.java
@@ -19,8 +19,7 @@ public final class EventLoggerUtils {
     public static EventBuilder createMasterEvent(
             KeycloakSession session,
             ClientConnection clientConnection) {
-
-        return createEvent(session, session.realms().getRealm(Config.getAdminRealm()),
+        return createEvent(session, session.realms().getRealmByName(Config.getAdminRealm()),
                 clientConnection);
     }
 

--- a/keycloak-plugins/radius-plugin/src/test/java/com/github/vzakharchenko/radius/radius/handlers/protocols/PAPTest.java
+++ b/keycloak-plugins/radius-plugin/src/test/java/com/github/vzakharchenko/radius/radius/handlers/protocols/PAPTest.java
@@ -171,7 +171,7 @@ public class PAPTest extends AbstractRadiusTest {
     public void testIsNotValid() {
         // request.addAttribute(REALM_RADIUS, "33");
         reset(realmProvider);
-        when(realmProvider.getRealm(Config.getAdminRealm())).thenReturn(realmModel);
+        when(realmProvider.getRealmByName(Config.getAdminRealm())).thenReturn(realmModel);
         PAPProtocol papProtocol = new PAPProtocol(request, session);
         assertFalse(papProtocol.isValid(new InetSocketAddress(0)));
     }

--- a/keycloak-plugins/radius-plugin/src/test/java/com/github/vzakharchenko/radius/radius/handlers/session/AuthRequestInitializationTest.java
+++ b/keycloak-plugins/radius-plugin/src/test/java/com/github/vzakharchenko/radius/radius/handlers/session/AuthRequestInitializationTest.java
@@ -114,7 +114,7 @@ public class AuthRequestInitializationTest extends AbstractRadiusTest {
     @Test
     public void testgetRadiusPasswordsRealmDoesNotExists() {
         RealmProvider provider = getProvider(RealmProvider.class);
-        when(provider.getRealm(REALM_RADIUS_NAME)).thenReturn(null);
+        when(provider.getRealm(REALM_RADIUS_ID)).thenReturn(null);
         when(authProtocol.getRealm()).thenReturn(null);
         assertFalse(authRequestInitialization
                 .init(inetSocketAddress, USER, authProtocol, session));
@@ -163,7 +163,7 @@ public class AuthRequestInitializationTest extends AbstractRadiusTest {
     @Test
     public void testgetafterAuthRealmERROR() {
         RealmProvider realmProvider = getProvider(RealmProvider.class);
-        when(realmProvider.getRealm(REALM_RADIUS_NAME)).thenReturn(null);
+        when(realmProvider.getRealm(REALM_RADIUS_ID)).thenReturn(null);
         authRequestInitialization
                 .afterAuth(4, session);
     }

--- a/keycloak-plugins/radius-plugin/src/test/java/com/github/vzakharchenko/radius/radius/handlers/session/KeycloakSessionUtilsTest.java
+++ b/keycloak-plugins/radius-plugin/src/test/java/com/github/vzakharchenko/radius/radius/handlers/session/KeycloakSessionUtilsTest.java
@@ -15,14 +15,14 @@ public class KeycloakSessionUtilsTest extends AbstractRadiusTest {
     public void getIsActiveSession() {
         when(userSessionProvider.getUserSession(eq(realmModel), anyString()))
                 .thenReturn(null);
-        assertFalse(KeycloakSessionUtils.isActiveSession(session, "test", REALM_RADIUS_NAME));
+        assertFalse(KeycloakSessionUtils.isActiveSession(session, "test", REALM_RADIUS_ID));
     }
 
     @Test
     public void getRadiusInfo() {
         assertNotNull(KeycloakSessionUtils.getRadiusUserInfo(session));
         assertNotNull(KeycloakSessionUtils.getRadiusSessionInfo(session));
-        assertTrue(KeycloakSessionUtils.isActiveSession(session, "test", REALM_RADIUS_NAME));
+        assertTrue(KeycloakSessionUtils.isActiveSession(session, "test", REALM_RADIUS_ID));
         when(session.getAttribute(anyString(), any())).thenReturn(null);
         assertNull(KeycloakSessionUtils.getRadiusSessionInfo(session));
     }

--- a/keycloak-plugins/radius-plugin/src/test/java/com/github/vzakharchenko/radius/test/AbstractRadiusTest.java
+++ b/keycloak-plugins/radius-plugin/src/test/java/com/github/vzakharchenko/radius/test/AbstractRadiusTest.java
@@ -20,6 +20,7 @@ import com.github.vzakharchenko.radius.radius.holder.IRadiusUserInfoBuilder;
 import com.github.vzakharchenko.radius.radius.holder.IRadiusUserInfoGetter;
 import com.github.vzakharchenko.radius.radius.server.KeycloakRadiusServer;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.keycloak.Config;
 import org.keycloak.authorization.AuthorizationProvider;
 import org.keycloak.authorization.policy.evaluation.PolicyEvaluator;
 import org.keycloak.authorization.store.ResourceServerStore;
@@ -62,7 +63,8 @@ public abstract class AbstractRadiusTest {
 
     public static final String RADIUS_SESSION_ID = "testSessionId";
     public static final String REALM_RADIUS = "realm-radius";
-    public static final String REALM_RADIUS_NAME = "RadiusName";
+    public static final String REALM_RADIUS_ID = "01234567-89ab-cdef-0123-456789abcdef";
+    public static final String REALM_RADIUS_NAME = "RadiusRealmName";
     public static final String CLIENT_ID = "CLIENT_ID";
     public static final String USER = "USER";
     @Mock
@@ -273,12 +275,14 @@ public abstract class AbstractRadiusTest {
         when(clientModel.getId()).thenReturn(CLIENT_ID);
         when(clientModel.getProtocol()).thenReturn(RadiusLoginProtocolFactory.RADIUS_PROTOCOL);
         when(clientModel.isEnabled()).thenReturn(true);
-        when(realmProvider.getRealm(REALM_RADIUS_NAME)).thenReturn(realmModel);
-        when(realmProvider.getRealm(anyString())).thenReturn(realmModel);
+        when(realmProvider.getRealm(REALM_RADIUS_ID)).thenReturn(realmModel);
+        when(realmProvider.getRealmByName(REALM_RADIUS_NAME)).thenReturn(realmModel);
+        // next one is needed for EventLoggerUtils in case an error is raised
+        when(realmProvider.getRealmByName(Config.getAdminRealm())).thenReturn(realmModel);
         when(realmProvider.getRealmsStream()).thenAnswer(i -> Stream.of(realmModel));
         when(realmModel.getClientByClientId(CLIENT_ID)).thenReturn(clientModel);
         when(realmModel.getName()).thenReturn(REALM_RADIUS_NAME);
-        when(realmModel.getId()).thenReturn(REALM_RADIUS_NAME);
+        when(realmModel.getId()).thenReturn(REALM_RADIUS_ID);
         when(realmModel.isEventsEnabled()).thenReturn(false);
         when(realmModel.getAttributes()).thenReturn(new HashMap<>());
         when(realmModel.getClientsStream()).thenAnswer(i -> Stream.of(clientModel));


### PR DESCRIPTION
RealmProvider can retrieve realms by ID (usually a UUID) or by name (the realm name specified e.g. when logging in with the username). The realm information from the RADIUS packages is always the name and therefore must be retrieved with RealmProvider#getRealmByName() instead of RealmProvider#getRealm(). (I'm not sure how this worked properly before and what change introduced the problem.) The test was also enhanced and adapted accordingly.