### PR TITLE
fix for multiple OTP token of the same type

### DIFF
--- a/docs/release/1.4.12.txt
+++ b/docs/release/1.4.12.txt
@@ -1,3 +1,4 @@
 - keycloak version 22.0.1
 - switch to JDK 17
 - replace test dependency com.github.stefanbirkner:system-lambda with the fork uk.org.webcompere:system-stubs-core to replace withEnvironmentVariable() by an applicable version for Java17
+- fix OTP verification for users with multiple tokens of same type (previously only token was checked)

--- a/keycloak-plugins/radius-plugin/src/main/java/com/github/vzakharchenko/radius/radius/handlers/otp/HotpPassword.java
+++ b/keycloak-plugins/radius-plugin/src/main/java/com/github/vzakharchenko/radius/radius/handlers/otp/HotpPassword.java
@@ -36,7 +36,7 @@ public class HotpPassword implements IOTPPassword {
                 credentialData.getAlgorithm(), policy.getLookAheadWindow());
         List<String> hotPs = getHOTPs(validator, secretData.getValue(),
                 credentialData.getCounter(), policy.getLookAheadWindow());
-        otpHolderMap.put(credentialData.getSubType(),
+        otpHolderMap.put(credential.getId(),
                 new OtpHolder(credentialData.getSubType(), credential, hotPs));
         return otpHolderMap;
     }

--- a/keycloak-plugins/radius-plugin/src/main/java/com/github/vzakharchenko/radius/radius/handlers/otp/OTPPasswordFactory.java
+++ b/keycloak-plugins/radius-plugin/src/main/java/com/github/vzakharchenko/radius/radius/handlers/otp/OTPPasswordFactory.java
@@ -15,7 +15,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import static org.keycloak.models.credential.OTPCredentialModel.HOTP;
 import static org.keycloak.models.credential.OTPCredentialModel.TOTP;
@@ -61,7 +60,8 @@ public class OTPPasswordFactory implements IOtpPasswordFactory {
                 .filter(credentialModel -> Objects
                         .equals(OTPCredentialModel.createFromCredentialModel(credentialModel)
                                 .getOTPCredentialData().getSubType(), realmModel
-                                .getOTPPolicy().getType())).collect(Collectors.toList());
+                                .getOTPPolicy().getType()))
+                .toList();
     }
 
     @Override

--- a/keycloak-plugins/radius-plugin/src/main/java/com/github/vzakharchenko/radius/radius/handlers/otp/TotpPassword.java
+++ b/keycloak-plugins/radius-plugin/src/main/java/com/github/vzakharchenko/radius/radius/handlers/otp/TotpPassword.java
@@ -46,7 +46,7 @@ public class TotpPassword implements IOTPPassword {
         List<String> totPs = getTOTPs(validator, credentialData,
                 secretData.getValue().getBytes(StandardCharsets.UTF_8),
                 policy.getLookAheadWindow());
-        otpHolderMap.put(credentialData.getSubType(),
+        otpHolderMap.put(credential.getId(),
                 new OtpHolder(credentialData.getSubType(), credential, totPs));
         return otpHolderMap;
     }

--- a/keycloak-plugins/radius-plugin/src/test/java/com/github/vzakharchenko/radius/radius/handlers/otp/HotpPasswordTest.java
+++ b/keycloak-plugins/radius-plugin/src/test/java/com/github/vzakharchenko/radius/radius/handlers/otp/HotpPasswordTest.java
@@ -16,19 +16,33 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
 public class HotpPasswordTest {
-    public static final String ALGORITHM = "sha1";
+    private static final String ALGORITHM = "sha1";
+    private static final String HOTP_ID = "myHotpId";
     private final HotpPassword hotpPassword = new HotpPassword();
 
     @Test
     public void testHotpPassword() {
+        testHotpPasswordInternal(HOTP_ID);
+    }
+
+    @Test
+    public void testHotpPasswordWithNullId() {
+        testHotpPasswordInternal(null);
+    }
+
+    private void testHotpPasswordInternal(String credentialId) {
         OTPCredentialData credentialData =
                 new OTPCredentialData(HOTP, 6, 1, 1, HmacOTP.HMAC_SHA1, null);
         OTPPolicy policy = new OTPPolicy(HOTP, ALGORITHM, 1, 6, 1, 1);
         CredentialModel credential = new CredentialModel();
+        if (credentialId != null) {
+           credential.setId(credentialId);
+        }
         Map<String, OtpHolder> otpPasswords = hotpPassword
                 .getOTPPasswords(credentialData, policy, new OTPSecretData("1"), credential);
         assertNotNull(otpPasswords);
-        OtpHolder otpHolder = otpPasswords.get(HOTP);
+        OtpHolder otpHolder = otpPasswords.get(credentialId);
+        assertNotNull(otpHolder);
         assertEquals(otpHolder.getCredentialModel(), credential);
         assertEquals(otpHolder.getSubType(), HOTP);
         List<String> passwords = otpHolder.getPasswords();

--- a/keycloak-plugins/radius-plugin/src/test/java/com/github/vzakharchenko/radius/radius/handlers/otp/OTPPasswordFactoryTest.java
+++ b/keycloak-plugins/radius-plugin/src/test/java/com/github/vzakharchenko/radius/radius/handlers/otp/OTPPasswordFactoryTest.java
@@ -59,11 +59,12 @@ public class OTPPasswordFactoryTest extends AbstractRadiusTest {
         OtpPasswordInfo otpPasswordInfo = otpPasswordFactory.getOTPs(session);
         Map<String, OtpHolder> otPs = otpPasswordInfo.getOtpHolderMap();
         assertEquals(otPs.size(), 1);
-        assertNotNull(otPs.get(TOTP));
-        assertEquals(otPs.get(TOTP).getSubType(), TOTP);
-        assertEquals(otPs.get(TOTP).getPasswords().size(), 1);
-        assertNotNull(otPs.get(TOTP).getPasswords().get(0));
-        assertEquals(otPs.get(TOTP).getPasswords().get(0).length(), 6);
+        OtpHolder otpHolder = otPs.get(CRED_ID);
+        assertNotNull(otpHolder);
+        assertEquals(otpHolder.getSubType(), TOTP);
+        assertEquals(otpHolder.getPasswords().size(), 1);
+        assertNotNull(otpHolder.getPasswords().get(0));
+        assertEquals(otpHolder.getPasswords().get(0).length(), 6);
     }
 
     @Test
@@ -84,18 +85,19 @@ public class OTPPasswordFactoryTest extends AbstractRadiusTest {
         OtpPasswordInfo otpPasswordInfo = otpPasswordFactory.getOTPs(session);
         Map<String, OtpHolder> otPs = otpPasswordInfo.getOtpHolderMap();
         assertEquals(otPs.size(), 1);
-        assertNotNull(otPs.get(HOTP));
-        assertEquals(otPs.get(HOTP).getSubType(), HOTP);
-        assertEquals(otPs.get(HOTP).getPasswords().size(), 1);
-        assertNotNull(otPs.get(HOTP).getPasswords().get(0));
-        assertEquals(otPs.get(HOTP).getPasswords().get(0).length(), 6);
+        OtpHolder otpHolder = otPs.get(CRED_ID);
+        assertNotNull(otpHolder);
+        assertEquals(otpHolder.getSubType(), HOTP);
+        assertEquals(otpHolder.getPasswords().size(), 1);
+        assertNotNull(otpHolder.getPasswords().get(0));
+        assertEquals(otpHolder.getPasswords().get(0).length(), 6);
     }
 
     @Test
     public void testValidOTP() {
         otpPasswordFactory.validOTP(session,
                 "1234",
-                "credId",
+                CRED_ID,
                 OTPCredentialModel.TYPE);
     }
 }


### PR DESCRIPTION
Use OTP token ID (or null if no ID is set) as mapping key instead the token type to allow users with use more than one token of the same type.

Previously, the last token found overwrote all previously found tokens of the same type, so that usually only the most recent token could be used via RADIUS. Now the OTP code is verified against all existing tokens.