### PR TITLE
add support for persistent providers to startDb.sh/saveDb.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,7 @@ Thumbs.db
 radius.config
 keycloak.properties
 keycloak-quarkus/data/*
+keycloak-quarkus/data.*/*
 release-steps.sh
 keycloak-plugins/*-plugin/git.properties
 keycloak-plugins/*-plugin/dependency-reduced-pom.xml

--- a/keycloak-quarkus/buildAndStartDb.sh
+++ b/keycloak-quarkus/buildAndStartDb.sh
@@ -21,4 +21,7 @@ cp data/cache-ispn.xml "${kc_dir}/conf"
 rm -rf "${kc_dir}/config/radius.config"
 cp data/radius.config "${kc_dir}/config/radius.config"
 
+# restore additional plugins and themes
+find data/providers -name "*.jar" -exec cp {} "${kc_dir}/providers/" \;
+
 ./start.sh

--- a/keycloak-quarkus/saveDb.sh
+++ b/keycloak-quarkus/saveDb.sh
@@ -1,14 +1,26 @@
 #!/usr/bin/env bash
-set -e
+set -e -x
 
 kc_ver='25.0.1'
 kc_dir="target/keycloak/keycloak-$kc_ver"
+timestamp="$(date +%Y%m%d-%H%M%S)"
 
 cd ../keycloak-quarkus
 
-mv data data.$(date +%Y%m%d-%H%M%S)
-mkdir data
+mv data "data.$timestamp"
+mkdir -p data/providers
 cp -r "${kc_dir}/data/h2" data/h2
 cp -r "${kc_dir}/conf/cache-ispn.xml" data/
 cp -r "${kc_dir}/conf/keycloak.conf" data/
 cp -r "${kc_dir}/config/radius.config" data/
+
+# save additional plugins and themes
+find "${kc_dir}/providers" -type f -name "*.jar" \! \( \
+       -name "cisco-radius-plugin-1.5.1-SNAPSHOT.jar" \
+    -o -name "mikrotik-radius-plugin-1.5.1-SNAPSHOT.jar" \
+    -o -name "chillispot-radius-plugin-1.5.1-SNAPSHOT.jar" \
+    -o -name "rad-sec-plugin-1.5.1-SNAPSHOT.jar" \
+    -o -name "radius-disconnect-plugin-1.5.1-SNAPSHOT.jar" \
+    -o -name "proxy-radius-plugin-1.5.1-SNAPSHOT.jar" \
+    -o -name "radius-plugin-1.5.1-SNAPSHOT.jar" \
+  \) -exec cp -v "{}" data/providers/ \;

--- a/keycloak-quarkus/start.sh
+++ b/keycloak-quarkus/start.sh
@@ -5,4 +5,5 @@ kc_ver='25.0.1'
 kc_dir="target/keycloak/keycloak-$kc_ver"
 
 cd "${kc_dir}"
-bin/kc.sh --debug 8190 start-dev --http-port=8090
+bin/kc.sh --debug 8190 start-dev --http-port=8090 \
+  --spi-theme-static-max-age=-1 --spi-theme-cache-themes=false --spi-theme-cache-templates=false


### PR DESCRIPTION
- additional plugins/themes (JARs) can be added to the saved Keycloak 'data/providers' folder
- add saved data directory backups to .gitignore